### PR TITLE
fix eb_shell_quote + stop using list2cmdline in submit_jobs

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -107,8 +107,11 @@ def eb_shell_quote(token):
     Wrap provided token in single quotes (to escape space and characters with special meaning in a shell),
     so it can be used in a shell command. This results in token that is not expanded/interpolated by the shell.
     """
+    # first, strip off double quotes that may wrap the entire value,
+    # we don't want to wrap single quotes around a double-quoted value
+    token = str(token).strip('"')
     # escape any non-escaped single quotes, and wrap entire token in single quotes
-    return "'%s'" % re.sub(r"(?<!\\)'", r"\'", str(token))
+    return "'%s'" % re.sub(r"(?<!\\)'", r"\'", token)
 
 vsc.utils.generaloption.shell_quote = eb_shell_quote
 

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -35,7 +35,6 @@ Support for PBS is provided via the PbsJob class. If you want you could create o
 import math
 import os
 import re
-import subprocess
 
 from easybuild.framework.easyblock import get_easyblock_instance
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS
@@ -134,12 +133,13 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     opts = [o for o in cmd_line_opts if not ignore_opts.match(o.split('=')[0])]
 
     # compose string with command line options, properly quoted and with '%' characters escaped
-    opts_str = subprocess.list2cmdline(opts).replace('%', '%%')
+    opts_str = ' '.join(opts).replace('%', '%%')
 
     command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s --testoutput=%%(output_dir)s" % (curdir, opts_str)
     _log.info("Command template for jobs: %s" % command)
     if testing:
         _log.debug("Skipping actual submission of jobs since testing mode is enabled")
+        return command
     else:
         return build_easyconfigs_in_parallel(command, ordered_ecs, prepare_first=prepare_first)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1876,11 +1876,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--suffix-modules-path=',
             '--try-toolchain=foss,2015b',
             '--logfile-format=easybuild,eb-%(name)s.log',
+            # option with spaces with value wrapped in double quotes, oh boy...
+            '--optarch="O3 -mtune=generic"',
         ]
         expected = [
             '--debug',
             "--installpath='/this/is/a/weird\\'prefix'",
             "--logfile-format='easybuild,eb-%(name)s.log'",
+            "--optarch='O3 -mtune=generic'",
             "--suffix-modules-path=''",
             "--test-report-env-filter='(COOKIE|SESSION)'",
             "--try-toolchain='foss,2015b'",

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -40,6 +40,7 @@ from easybuild.tools import config
 from easybuild.tools.filetools import adjust_permissions, mkdir, which, write_file
 from easybuild.tools.job import pbs_python
 from easybuild.tools.job.pbs_python import PbsPython
+from easybuild.tools.options import parse_options
 from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel, submit_jobs
 from easybuild.tools.robot import resolve_dependencies
 
@@ -218,6 +219,46 @@ class ParallelBuildTest(EnhancedTestCase):
 
         self.assertTrue(os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0'))
         self.assertTrue(os.path.join(self.test_installpath, 'software', 'toy', '0.0', 'bin', 'toy'))
+
+    def test_submit_jobs(self):
+        """Test submit_jobs"""
+        test_easyconfigs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_easyconfigs_dir, 't', 'toy', 'toy-0.0.eb')
+
+        args = [
+            '--debug',
+            '--tmpdir', '/tmp',
+            '--optarch="GCC:O3 -mtune=generic;Intel:O3 -xHost"',
+            '--parallel=2',
+            '--try-toolchain=intel,2016a',  # should be excluded in job script
+            '--robot', self.test_prefix,  # should be excluded in job script
+            '--job',  # should be excluded in job script
+        ]
+        eb_go = parse_options(args=args)
+        cmd = submit_jobs([toy_ec], eb_go.generate_cmd_line(), testing=True)
+
+        # these patterns must be found
+        regexs = [
+            ' --debug ',
+            # values got wrapped in single quotes (to avoid interpretation by shell)
+            " --tmpdir='/tmp' ",
+            " --parallel='2' ",
+            # (unparsed) optarch value got wrapped in single quotes, double quotes got stripped
+            " --optarch='GCC:O3 -mtune=generic;Intel:O3 -xHost' ",
+            # templates to be completed via build_easyconfigs_in_parallel -> create_job
+            ' eb %\(spec\)s ',
+            ' %\(add_opts\)s ',
+            ' --testoutput=%\(output_dir\)s',
+        ]
+        for regex in regexs:
+            regex = re.compile(regex)
+            self.assertTrue(regex.search(cmd), "Pattern '%s' found in: %s" % (regex.pattern, cmd))
+
+        # these patterns should NOT be found, these options get filtered out
+        # (self.test_prefix was argument to --robot)
+        for regex in ['--job', '--try-toolchain', '--robot=[ =]', self.test_prefix + ' ']:
+            regex = re.compile(regex)
+            self.assertFalse(regex.search(cmd), "Pattern '%s' *not* found in: %s" % (regex.pattern, cmd))
 
 
 def suite():


### PR DESCRIPTION
I had to drop the use of `list2cmdline` since, for some reason, it was wrapping the whole `--optarch='...'` in double quotes to generate the command, which is wrong since then the single quotes are exposed to the value passed to EasyBuild...

Since `generate_cmd_line` already takes care of wrapping all values in single quotes (via `eb_shell_quote`), there's no need for `list2cmdline` imho.

Travis approves: https://travis-ci.org/boegel/easybuild-framework/builds/216662573