### PR TITLE
clean up back_up_file implementation & test

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1186,14 +1186,14 @@ def back_up_file(src_file, backup_extension='', hidden=False):
     :param backup_extension: optional extension to use for the backup file
     :param hidden: make backup hidden (leading dot in filename)
     """
-    fn_pref, fn_suff = '', ''
+    fn_prefix, fn_suffix = '', ''
     if hidden:
-        fn_pref = '.'
+        fn_prefix = '.'
     if backup_extension:
-        fn_suff = '.%s' % backup_extension
+        fn_suffix = '.%s' % backup_extension
 
     src_dir, src_fn = os.path.split(src_file)
-    backup_fp = find_backup_name_candidate(os.path.join(src_dir, fn_pref + src_fn + fn_suff))
+    backup_fp = find_backup_name_candidate(os.path.join(src_dir, fn_prefix + src_fn + fn_suffix))
 
     copy_file(src_file, backup_fp)
     _log.info("File %s backed up in %s", src_file, backup_fp)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1177,35 +1177,28 @@ def find_backup_name_candidate(src_file):
     return dst_file
 
 
-def back_up_file(src_file, backup_extension="", hidden=False):
+def back_up_file(src_file, backup_extension='', hidden=False):
     """
     Backs up a file appending a backup extension and a number to it (if there is already an existing backup). Returns
     the name of the backup
 
     :param src_file: file to be back up
-    :param backup_extension: optional extension of the backup
-    :param hidden: make a hidden (leading dot) backup
+    :param backup_extension: optional extension to use for the backup file
+    :param hidden: make backup hidden (leading dot in filename)
     """
+    fn_pref, fn_suff = '', ''
     if hidden:
-        leading_string = "."
-    else:
-        leading_string = ""
-
+        fn_pref = '.'
     if backup_extension:
-        trailing_string = ".%s" % backup_extension
-    else:
-        trailing_string = ""
+        fn_suff = '.%s' % backup_extension
 
-    backup_file = find_backup_name_candidate("%s/%s%s%s" % \
-            (os.path.dirname(src_file),\
-            leading_string,\
-            os.path.basename(src_file),\
-            trailing_string))
+    src_dir, src_fn = os.path.split(src_file)
+    backup_fp = find_backup_name_candidate(os.path.join(src_dir, fn_pref + src_fn + fn_suff))
 
-    copy_file(src_file, backup_file)
-    _log.info("File %s backed up in %s" % (src_file, backup_file))
+    copy_file(src_file, backup_fp)
+    _log.info("File %s backed up in %s", src_file, backup_fp)
 
-    return backup_file
+    return backup_fp
 
 
 def move_logs(src_logfile, target_logfile):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -496,50 +496,76 @@ class FileToolsTest(EnhancedTestCase):
 
     def test_back_up_file(self):
         """Test back_up_file function."""
-        fh, fp = tempfile.mkstemp()
-        os.close(fh)
+        fp = os.path.join(self.test_prefix, 'sandbox', 'test.txt')
+        txt = 'foobar'
+        ft.write_file(fp, txt)
 
-        ft.write_file(fp, 'foobar')
+        test_files = ['test.txt']
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
 
         # Test simple file backup
         ft.back_up_file(fp)
-        self.assertEqual(ft.read_file(fp+'_0'), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar')
+        test_files.append('test.txt_0')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), 'test.txt_0')), txt)
+        self.assertEqual(ft.read_file(fp), txt)
+
         # Test hidden simple file backup
         ft.back_up_file(fp, hidden=True)
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar')
-        # Test simple file backup with extension
-        ft.back_up_file(fp, backup_extension="bck")
-        self.assertEqual(ft.read_file(fp+'.bck'), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar')
-        # Test hidden simple file backup with extension
-        ft.back_up_file(fp, backup_extension="bck", hidden=True)
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)+'.bck'), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar')
+        test_files.insert(0, '.test.txt')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt')), txt)
+        self.assertEqual(ft.read_file(fp), txt)
 
-        ft.write_file(fp, 'foobar2')
+        # Test simple file backup with extension
+        ft.back_up_file(fp, backup_extension='bck')
+        test_files.insert(2, 'test.txt.bck')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), 'test.txt.bck')), txt)
+        self.assertEqual(ft.read_file(fp), txt)
+
+        # Test hidden simple file backup with extension
+        ft.back_up_file(fp, backup_extension='bck', hidden=True)
+        test_files.insert(1, '.test.txt.bck')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt.bck')), txt)
+        self.assertEqual(ft.read_file(fp), txt)
+
+        new_txt = 'barfoo'
+        ft.write_file(fp, new_txt)
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
 
         # Test file backup with existing backup
         ft.back_up_file(fp)
-        self.assertEqual(ft.read_file(fp+'_0'), 'foobar')
-        self.assertEqual(ft.read_file(fp+'_1'), 'foobar2')
-        self.assertEqual(ft.read_file(fp), 'foobar2')
+        test_files.append('test.txt_1')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), 'test.txt_0')), txt)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), 'test.txt_1')), new_txt)
+        self.assertEqual(ft.read_file(fp), new_txt)
+
         # Test hidden file backup with existing backup
         ft.back_up_file(fp, hidden=True)
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)+'_0'), 'foobar2')
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar2')
+        test_files.insert(2, '.test.txt_0')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt')), txt)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt_0')), new_txt)
+        self.assertEqual(ft.read_file(fp), new_txt)
+
         # Test file backup with extension and existing backup
-        ft.back_up_file(fp, backup_extension="bck")
-        self.assertEqual(ft.read_file(fp+'.bck_0'), 'foobar2')
-        self.assertEqual(ft.read_file(fp+'.bck'), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar2')
+        ft.back_up_file(fp, backup_extension='bck')
+        test_files.insert(5, 'test.txt.bck_0')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(fp+'.bck_0'), new_txt)
+        self.assertEqual(ft.read_file(fp+'.bck'), txt)
+        self.assertEqual(ft.read_file(fp), new_txt)
+
         # Test hidden file backup with extension and existing backup
-        ft.back_up_file(fp, backup_extension="bck", hidden=True)
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)+'.bck_0'), 'foobar2')
-        self.assertEqual(ft.read_file(os.path.dirname(fp)+'/.'+os.path.basename(fp)+'.bck'), 'foobar')
-        self.assertEqual(ft.read_file(fp), 'foobar2')
+        ft.back_up_file(fp, backup_extension='bck', hidden=True)
+        test_files.insert(2, '.test.txt.bck_0')
+        self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), test_files)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt.bck')), txt)
+        self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), '.test.txt.bck_0')), new_txt)
+        self.assertEqual(ft.read_file(fp), new_txt)
 
     def test_move_logs(self):
         """Test move_logs function."""


### PR DESCRIPTION
First round of cleanup for https://github.com/easybuilders/easybuild-framework/pull/2134, only touching `back_up_file` for now; more to come (trying to send you bite-sized PRs)

Re-ran the original test after cleaning up `back_up_file` to make sure behaviour remains the same, then also cleaned up test.

One thing that came to mind is that it's maybe better to back up files with a more meaningful filename like `test.txt_201708170828`, i.e. date + timestamp as increasing number, and on a clash, we can simply sleep for 1 sec and try again?