### PR TITLE
rework support for --backup-modules

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2221,9 +2221,9 @@ class EasyBlock(object):
                 diff_msg = "comparing module file with backup %s; " % self.mod_file_backup
                 mod_diff = diff_files(self.mod_file_backup, mod_filepath)
                 if mod_diff:
-                    diff_msg += ' diff is:\n%s' % mod_diff
+                    diff_msg += 'diff is:\n%s' % mod_diff
                 else:
-                    diff_msg += ' no differences found.'
+                    diff_msg += 'no differences found'
                 self.log.info(diff_msg)
                 print_msg(diff_msg)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1481,7 +1481,7 @@ class EasyBlock(object):
 
         # create backup of existing module file (if requested)
         if os.path.exists(self.mod_filepath) and build_option('backup_modules'):
-            # backups of modules in Tcl syntax should be hidden to avoid they they're shown in 'module avail';
+            # backups of modules in Tcl syntax should be hidden to avoid that they're shown in 'module avail';
             # backups of modules in Lua syntax do not need to be hidden:
             # since they don't end in .lua (but in .lua.bck_*) Lmod will not pick them up anymore,
             # which is better than hiding them (since --show-hidden still reveals them)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -102,6 +102,7 @@ def mk_full_default_path(name, prefix=DEFAULT_PREFIX):
 BUILD_OPTIONS_CMDLINE = {
     None: [
         'aggregate_regtest',
+        'backup_modules',
         'download_timeout',
         'dump_test_report',
         'easyblock',
@@ -177,7 +178,6 @@ BUILD_OPTIONS_CMDLINE = {
         'set_default_module',
     ],
     True: [
-        'backup_modules',
         'cleanup_builddir',
         'cleanup_easyconfigs',
         'cleanup_tmpdir',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -38,6 +38,7 @@ Set of file tools.
 :author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 import datetime
+import difflib
 import fileinput
 import glob
 import hashlib
@@ -1604,3 +1605,12 @@ def move_file(path, target_path, force_in_dry_run=False):
             _log.info("%s moved to %s", path, target_path)
         except (IOError, OSError) as err:
             raise EasyBuildError("Failed to move %s to %s: %s", path, target_path, err)
+
+
+def diff_files(path1, path2):
+    """
+    Return unified diff between two files
+    """
+    file1_lines = ['%s\n' % l for l in read_file(path1).split('\n')]
+    file2_lines = ['%s\n' % l for l in read_file(path2).split('\n')]
+    return ''.join(difflib.unified_diff(file1_lines, file2_lines, fromfile=path1, tofile=path2))

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -174,25 +174,6 @@ class ModuleGenerator(object):
 
         return os.path.join(mod_path, mod_path_suffix)
 
-    def prepare(self, fake=False):
-        """
-        Prepare for generating module file: Creates the absolute filename for the module.
-        """
-        mod_path = self.get_modules_path(fake=fake)
-        # module file goes in general moduleclass category
-        # make symlink in moduleclass category
-
-        mod_filepath = self.get_module_filepath(fake=fake)
-        mkdir(os.path.dirname(mod_filepath), parents=True)
-
-        # remove module file if it's there (it'll be recreated), see EasyBlock.make_module
-        if os.path.exists(mod_filepath) and not build_option('extended_dry_run') and \
-                (not build_option('backup_modules') or fake):
-            self.log.debug("Removing existing module file %s", mod_filepath)
-            os.remove(mod_filepath)
-
-        return mod_path
-
     # From this point on just not implemented methods
 
     def comment(self, msg):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -325,7 +325,7 @@ class EasyBuildOptions(GeneralOption):
             'allow-use-as-root-and-accept-consequences': ("Allow using of EasyBuild as root (NOT RECOMMENDED!)",
                                                           None, 'store_true', False),
             'backup-modules': ("Back up an existing module file, if any. Only works when using --module-only",
-                            None, 'store_true', False),
+                               None, 'store_true', False),
             'check-ebroot-env-vars': ("Action to take when defined $EBROOT* environment variables are found "
                                       "for which there is no matching loaded module; "
                                       "supported values: %s" % ', '.join(EBROOT_ENV_VAR_ACTIONS), None, 'store', WARN),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -325,7 +325,7 @@ class EasyBuildOptions(GeneralOption):
             'allow-use-as-root-and-accept-consequences': ("Allow using of EasyBuild as root (NOT RECOMMENDED!)",
                                                           None, 'store_true', False),
             'backup-modules': ("Back up an existing module file, if any. Only works when using --module-only",
-                               None, 'store_true', False),
+                               None, 'store_true', None),  # default None to allow auto-enabling if not disabled
             'check-ebroot-env-vars': ("Action to take when defined $EBROOT* environment variables are found "
                                       "for which there is no matching loaded module; "
                                       "supported values: %s" % ', '.join(EBROOT_ENV_VAR_ACTIONS), None, 'store', WARN),
@@ -754,6 +754,11 @@ class EasyBuildOptions(GeneralOption):
         # imply --terse for --last-log to avoid extra output that gets in the way
         if self.options.last_log:
             self.options.terse = True
+
+        # auto-enable --backup-modules with --skip and --module-only, unless it was hard disabled
+        if (self.options.module_only or self.options.skip) and self.options.backup_modules is None:
+            self.log.debug("Auto-enabling --backup-modules because of --module-only or --skip")
+            self.options.backup_modules = True
 
         # make sure --optarch has a valid format, but do it only if we are not going to submit jobs. Otherwise it gets
         # processed twice and fails when trying to parse a dictionary as if it was a string

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -720,10 +720,6 @@ class EasyBuildOptions(GeneralOption):
             build_easyconfig_constants_dict()  # runs the easyconfig constants sanity check
             self._postprocess_list_avail()
 
-        # if --backup-modules is used without --module-only print a warning
-        if self.options.backup_modules and not self.options.module_only:
-            print_warning("--backup-modules can be used just together with --module-only. Ignoring it...")
-
         # fail early if required dependencies for functionality requiring using GitHub API are not available:
         if self.options.from_pr or self.options.upload_test_report:
             if not HAVE_GITHUB_API:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1428,8 +1428,6 @@ class FileToolsTest(EnhancedTestCase):
             'five',
         ]))
         expected = '\n'.join([
-            "--- %s" % foo,
-            "+++ %s" % bar,
             "@@ -1,5 +1,6 @@",
             "-one",
             "+zero",
@@ -1441,7 +1439,10 @@ class FileToolsTest(EnhancedTestCase):
             " five",
             '',
         ])
-        self.assertEqual(ft.diff_files(foo, bar), expected)
+        res = ft.diff_files(foo, bar)
+        self.assertTrue(res.endswith(expected), "%s ends with %s" % (res, expected))
+        regex = re.compile('^--- .*/foo\s*\n\+\+\+ .*/bar\s*$', re.M)
+        self.assertTrue(regex.search(res), "Pattern '%s' found in: %s" % (regex.pattern, res))
 
 
 def suite():

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1408,6 +1408,41 @@ class FileToolsTest(EnhancedTestCase):
         fn = os.path.basename(res)
         self.assertTrue(regex.match(fn), "'%s' matches pattern '%s'" % (fn, regex.pattern))
 
+    def test_diff_files(self):
+        """Test for diff_files function"""
+        foo = os.path.join(self.test_prefix, 'foo')
+        ft.write_file(foo, '\n'.join([
+            'one',
+            'two',
+            'three',
+            'four',
+            'five',
+        ]))
+        bar = os.path.join(self.test_prefix, 'bar')
+        ft.write_file(bar, '\n'.join([
+            'zero',
+            '1',
+            'two',
+            'tree',
+            'four',
+            'five',
+        ]))
+        expected = '\n'.join([
+            "--- %s" % foo,
+            "+++ %s" % bar,
+            "@@ -1,5 +1,6 @@",
+            "-one",
+            "+zero",
+            "+1",
+            " two",
+            "-three",
+            "+tree",
+            " four",
+            " five",
+            '',
+        ])
+        self.assertEqual(ft.diff_files(foo, bar), expected)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -43,6 +43,12 @@ from easybuild.tools.run import run_cmd
 class EB_toy(EasyBlock):
     """Support for building/installing toy."""
 
+    def __init__(self, *args, **kwargs):
+        """Constructor"""
+        super(EB_toy, self).__init__(*args, **kwargs)
+
+        setvar('TOY', '%s-%s' % (self.name, self.version))
+
     def prepare_for_extensions(self):
         """
         Prepare for installing toy extensions.
@@ -62,8 +68,6 @@ class EB_toy(EasyBlock):
 
         if os.path.exists("%s.source" % name):
             os.rename('%s.source' % name, '%s.c' % name)
-
-        setvar('TOY', '%s-%s' % (self.name, self.version))
 
     def build_step(self, name=None, buildopts=None):
         """Build toy."""


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-framework/pull/2134

Changes made:

* don't require that `--backup-modules` is used together with `--module-only`, I think it's also useful in other situations (e.g. when forcibly overwriting an installation with `--force`, or when using `--skip` to inject additional extensions)
* add `diff_files` function that leverages `difflib.unified_diff` module in Python stdlib, and use that rather than calling out to `diff -u`
* remove `prepare` method in `module_generator.py`, since it's completely useless now and only lead to duplicate code (e.g. removal of already existing module file, which is handled already in `check_readiness_step` in `easyblock.py`

With this included, I feel https://github.com/easybuilders/easybuild-framework/pull/2134 is pretty much ready to go, let me know what you think @damianam!